### PR TITLE
Update Website with Example Grad Program Meeting Documents

### DIFF
--- a/handbook/gradreports.md
+++ b/handbook/gradreports.md
@@ -1,0 +1,12 @@
+---
+title: Graduate School Reports
+---
+
+{% include breadcrumbs.html %}
+
+# {% include icon.html icon="fa-solid fa-graduation-cap" %} Graduate School Meeting Reports 
+
+As part of the Scripps Research Graduate Program, Ph.D. students are expected to participate in regularly scheduled committee meetings. These meetings include both written reports and oral presentations that serve to evaluate each student's progress throughout the program. Detailed information about the various types of committee meetings can be found on this [page](https://scrippsresearch.sharepoint.com/sites/education/SitePages/Committee-Meeting-Types.aspx). 
+
+For reference, curated example reports from students in the Su and Wu labs are available in this [folder](https://drive.google.com/drive/folders/1hiyH3JaLi2IplZPoyFuTl8eSZKkQ86yy?usp=sharing). Please request access by clicking on the link to view the contents. Additional sample documents and research plans from across the graduate program can be accessed [here](https://scrippsresearch.sharepoint.com/sites/education/SitePages/Committees-Sample-Research-Plans.aspx) or by contacting the graduate program office directly.
+

--- a/handbook/index.md
+++ b/handbook/index.md
@@ -33,6 +33,7 @@ For more on general Scripps information and policies (including campus maps, sec
 
 ## Graduate students
 * [Individual Development Plans](/handbook/idp)
+* [Example Meeting Reports](/handbook/gradreports)
 * [lllustrated Guide to a Ph.D.](http://matt.might.net/articles/phd-school-in-pictures/) by [Matt Might](https://matt.might.net/)
 
 {% include section.html %}


### PR DESCRIPTION
Updating website with pages with example graduate program reports, and an updated handbook index page to reflect the same. 

