### PR TITLE
Convert viz pages to light theme

### DIFF
--- a/lotz-ivd/index.html
+++ b/lotz-ivd/index.html
@@ -4,20 +4,20 @@
 <meta charset="UTF-8">
 <title>IVD Atlas — Spec Evolution</title>
 <style>
-  body { background: #0f1923; color: #ccd6e0; font-family: 'Segoe UI', system-ui, sans-serif;
+  body { background: #f5f7fa; color: #1a202c; font-family: 'Segoe UI', system-ui, sans-serif;
          display: flex; flex-direction: column; align-items: center; justify-content: center;
          min-height: 100vh; margin: 0; padding: 2rem; }
-  .card { background: #162433; border-radius: 14px; padding: 2.5rem 3rem;
-          border: 1px solid #1e3448; max-width: 640px; width: 100%; }
-  h1 { color: white; font-size: 1.5rem; margin-bottom: 0.3rem; }
-  .sub { color: #7a99b0; font-size: 0.9rem; margin-bottom: 2rem; }
+  .card { background: #ffffff; border-radius: 14px; padding: 2.5rem 3rem;
+          border: 1px solid #e2e8f0; max-width: 640px; width: 100%; }
+  h1 { color: #1a202c; font-size: 1.5rem; margin-bottom: 0.3rem; }
+  .sub { color: #64748b; font-size: 0.9rem; margin-bottom: 2rem; }
   ul { list-style: none; padding: 0; display: flex; flex-direction: column; gap: 0.8rem; }
-  li a { display: block; background: #1a2e40; border-radius: 8px; padding: 0.9rem 1.2rem;
-          text-decoration: none; color: #ccd6e0; border: 1px solid #1e3448;
+  li a { display: block; background: #f0f4f8; border-radius: 8px; padding: 0.9rem 1.2rem;
+          text-decoration: none; color: #1a202c; border: 1px solid #e2e8f0;
           transition: border-color 0.15s, background 0.15s; }
-  li a:hover { background: #213447; border-color: #57c4ad; }
-  li a .title { color: white; font-weight: 600; font-size: 0.95rem; }
-  li a .desc  { color: #7a99b0; font-size: 0.8rem; margin-top: 0.2rem; }
+  li a:hover { background: #e8f0fe; border-color: #2a9d8f; }
+  li a .title { color: #1a202c; font-weight: 600; font-size: 0.95rem; }
+  li a .desc  { color: #64748b; font-size: 0.8rem; margin-top: 0.2rem; }
 </style>
 </head>
 <body>

--- a/lotz-ivd/viz1_stacked_growth.html
+++ b/lotz-ivd/viz1_stacked_growth.html
@@ -5,15 +5,15 @@
 <title>Viz 1 · Spec Corpus Growth</title>
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
 <style>
-  body { background: #0f1923; color: #ccd6e0; font-family: 'Segoe UI', system-ui, sans-serif;
+  body { background: #f5f7fa; color: #1a202c; font-family: 'Segoe UI', system-ui, sans-serif;
          display: flex; flex-direction: column; align-items: center; justify-content: center;
          min-height: 100vh; margin: 0; padding: 2rem; }
-  .card { background: #162433; border-radius: 14px; padding: 2rem 2.5rem;
-          border: 1px solid #1e3448; width: 100%; max-width: 960px; }
-  h2 { color: white; font-size: 1.4rem; margin-bottom: 0.3rem; }
-  .desc { color: #7a99b0; font-size: 0.88rem; margin-bottom: 1.5rem; line-height: 1.5; max-width: 80ch; }
-  .nav { margin-top: 1.5rem; font-size: 0.8rem; color: #445566; }
-  .nav a { color: #57c4ad; text-decoration: none; margin: 0 0.5rem; }
+  .card { background: #ffffff; border-radius: 14px; padding: 2rem 2.5rem;
+          border: 1px solid #e2e8f0; width: 100%; max-width: 960px; }
+  h2 { color: #1a202c; font-size: 1.4rem; margin-bottom: 0.3rem; }
+  .desc { color: #64748b; font-size: 0.88rem; margin-bottom: 1.5rem; line-height: 1.5; max-width: 80ch; }
+  .nav { margin-top: 1.5rem; font-size: 0.8rem; color: #94a3b8; }
+  .nav a { color: #2a9d8f; text-decoration: none; margin: 0 0.5rem; }
 </style>
 </head>
 <body>
@@ -34,8 +34,8 @@
 </div>
 
 <script>
-Chart.defaults.color = '#7a99b0';
-Chart.defaults.borderColor = '#1e3448';
+Chart.defaults.color = '#64748b';
+Chart.defaults.borderColor = '#e2e8f0';
 
 const DATES = ['Feb 26', 'Feb 27', 'Mar 9', 'Mar 10', 'Mar 20', 'Apr 9', 'Apr 13'];
 const SPECS = [
@@ -72,7 +72,7 @@ new Chart(document.getElementById('chart'), {
       label: sp,
       data: DATA[sp],
       backgroundColor: COLORS[i],
-      borderColor: '#0f1923',
+      borderColor: '#ffffff',
       borderWidth: 0.8,
       stack: 'stack',
     }))
@@ -82,7 +82,7 @@ new Chart(document.getElementById('chart'), {
     plugins: {
       legend: {
         position: 'right',
-        labels: { boxWidth: 14, font: { size: 12 }, color: '#ccd6e0', padding: 10 }
+        labels: { boxWidth: 14, font: { size: 12 }, color: '#1a202c', padding: 10 }
       },
       tooltip: {
         callbacks: {
@@ -93,14 +93,14 @@ new Chart(document.getElementById('chart'), {
     scales: {
       x: {
         stacked: true,
-        ticks: { color: '#ccd6e0', font: { size: 12 } },
-        grid: { color: '#1e3448' }
+        ticks: { color: '#1a202c', font: { size: 12 } },
+        grid: { color: '#e2e8f0' }
       },
       y: {
         stacked: true,
-        ticks: { color: '#ccd6e0' },
-        grid: { color: '#1e3448' },
-        title: { display: true, text: 'Total lines of spec', color: '#7a99b0', font: { size: 12 } }
+        ticks: { color: '#1a202c' },
+        grid: { color: '#e2e8f0' },
+        title: { display: true, text: 'Total lines of spec', color: '#64748b', font: { size: 12 } }
       }
     }
   }

--- a/lotz-ivd/viz2_heatmap.html
+++ b/lotz-ivd/viz2_heatmap.html
@@ -4,25 +4,25 @@
 <meta charset="UTF-8">
 <title>Viz 2 · Human Attention Heatmap</title>
 <style>
-  body { background: #0f1923; color: #ccd6e0; font-family: 'Segoe UI', system-ui, sans-serif;
+  body { background: #f5f7fa; color: #1a202c; font-family: 'Segoe UI', system-ui, sans-serif;
          display: flex; flex-direction: column; align-items: center; justify-content: center;
          min-height: 100vh; margin: 0; padding: 2rem; }
-  .card { background: #162433; border-radius: 14px; padding: 2rem 2.5rem;
-          border: 1px solid #1e3448; width: 100%; max-width: 960px; }
-  h2 { color: white; font-size: 1.4rem; margin-bottom: 0.3rem; }
-  .desc { color: #7a99b0; font-size: 0.88rem; margin-bottom: 1.5rem; line-height: 1.5; max-width: 80ch; }
+  .card { background: #ffffff; border-radius: 14px; padding: 2rem 2.5rem;
+          border: 1px solid #e2e8f0; width: 100%; max-width: 960px; }
+  h2 { color: #1a202c; font-size: 1.4rem; margin-bottom: 0.3rem; }
+  .desc { color: #64748b; font-size: 0.88rem; margin-bottom: 1.5rem; line-height: 1.5; max-width: 80ch; }
   table { border-collapse: collapse; width: 100%; }
-  th { color: #7a99b0; font-weight: 600; font-size: 11px; padding: 6px 10px; text-align: center; white-space: nowrap; }
+  th { color: #64748b; font-weight: 600; font-size: 11px; padding: 6px 10px; text-align: center; white-space: nowrap; }
   th.spec-col { text-align: left; min-width: 130px; }
-  td { padding: 5px 8px; font-size: 12px; text-align: center; border: 1px solid #0f1923; border-radius: 3px; font-weight: 600; }
-  td.spec-label { text-align: left; color: #ccd6e0; font-weight: 400; white-space: nowrap; padding-right: 16px; }
-  .legend { display: flex; gap: 16px; align-items: center; margin-top: 14px; font-size: 11px; color: #7a99b0; }
+  td { padding: 5px 8px; font-size: 12px; text-align: center; border: 1px solid #f5f7fa; border-radius: 3px; font-weight: 600; }
+  td.spec-label { text-align: left; color: #1a202c; font-weight: 400; white-space: nowrap; padding-right: 16px; }
+  .legend { display: flex; gap: 16px; align-items: center; margin-top: 14px; font-size: 11px; color: #64748b; }
   .swatch { display: inline-block; width: 32px; height: 14px; border-radius: 3px; vertical-align: middle; margin-right: 4px; }
-  .nav { margin-top: 1.5rem; font-size: 0.8rem; color: #445566; }
-  .nav a { color: #57c4ad; text-decoration: none; margin: 0 0.5rem; }
+  .nav { margin-top: 1.5rem; font-size: 0.8rem; color: #94a3b8; }
+  .nav a { color: #2a9d8f; text-decoration: none; margin: 0 0.5rem; }
 
   /* Column header annotations */
-  .col-note { font-size: 9px; color: #557799; font-weight: 400; display: block; }
+  .col-note { font-size: 9px; color: #94a3b8; font-weight: 400; display: block; }
 </style>
 </head>
 <body>
@@ -41,7 +41,7 @@
     <span><span class="swatch" style="background:#1a6b96"></span>lines added</span>
     <span><span class="swatch" style="background:rgba(26,107,150,0.3)"></span>small addition</span>
     <span><span class="swatch" style="background:#e76f51"></span>lines removed</span>
-    <span><span class="swatch" style="background:#0f1923;border:1px solid #334455"></span>unchanged</span>
+    <span><span class="swatch" style="background:#f5f7fa;border:1px solid #e2e8f0"></span>unchanged</span>
   </div>
 
   <div class="nav">
@@ -77,25 +77,25 @@ const DATA = {
 };
 
 function cellColor(v) {
-  if (v === 0) return '#0f1923';
+  if (v === 0) return '#f5f7fa';
   const max = 230;
   const t = Math.min(Math.abs(v) / max, 1);
   if (v > 0) {
-    const r = Math.round(15  + t * (26 - 15));
-    const g = Math.round(36  + t * (107 - 36));
-    const b = Math.round(55  + t * (210 - 55));
+    const r = Math.round(235 - t * (235 - 26));
+    const g = Math.round(245 - t * (245 - 107));
+    const b = Math.round(255 - t * (255 - 210));
     return `rgb(${r},${g},${b})`;
   } else {
-    const r = Math.round(80  + t * (231 - 80));
-    const g = Math.round(30  + t * (20));
-    const b = Math.round(30  + t * (10));
+    const r = Math.round(255 - t * (255 - 231));
+    const g = Math.round(235 - t * (235 - 20));
+    const b = Math.round(235 - t * (235 - 10));
     return `rgb(${r},${g},${b})`;
   }
 }
 
 function textColor(v, bg) {
-  if (v === 0) return '#334455';
-  return Math.abs(v) > 50 ? 'white' : '#ccd6e0';
+  if (v === 0) return '#94a3b8';
+  return Math.abs(v) > 50 ? 'white' : '#1a202c';
 }
 
 const table = document.getElementById('heatmap');
@@ -119,10 +119,10 @@ SPECS.forEach(sp => {
 });
 
 // Totals row
-html += '<tr style="border-top:2px solid #334455"><td class="spec-label" style="color:#7a99b0">Total lines</td>';
+html += '<tr style="border-top:2px solid #e2e8f0"><td class="spec-label" style="color:#64748b">Total lines</td>';
 DATES.forEach((_, ci) => {
   const total = SPECS.reduce((s, sp) => s + DATA[sp][ci], 0);
-  html += `<td style="background:#1a2e40;color:#e9c46a;font-size:11px">${total.toLocaleString()}</td>`;
+  html += `<td style="background:#f0f4f8;color:#c47c00;font-size:11px">${total.toLocaleString()}</td>`;
 });
 html += '</tr></tbody>';
 

--- a/lotz-ivd/viz3_timeline.html
+++ b/lotz-ivd/viz3_timeline.html
@@ -5,17 +5,17 @@
 <title>Viz 3 · Commit Timeline</title>
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
 <style>
-  body { background: #0f1923; color: #ccd6e0; font-family: 'Segoe UI', system-ui, sans-serif;
+  body { background: #f5f7fa; color: #1a202c; font-family: 'Segoe UI', system-ui, sans-serif;
          display: flex; flex-direction: column; align-items: center; justify-content: center;
          min-height: 100vh; margin: 0; padding: 2rem; }
-  .card { background: #162433; border-radius: 14px; padding: 2rem 2.5rem;
-          border: 1px solid #1e3448; width: 100%; max-width: 960px; }
-  h2 { color: white; font-size: 1.4rem; margin-bottom: 0.3rem; }
-  .desc { color: #7a99b0; font-size: 0.88rem; margin-bottom: 1.5rem; line-height: 1.5; max-width: 80ch; }
+  .card { background: #ffffff; border-radius: 14px; padding: 2rem 2.5rem;
+          border: 1px solid #e2e8f0; width: 100%; max-width: 960px; }
+  h2 { color: #1a202c; font-size: 1.4rem; margin-bottom: 0.3rem; }
+  .desc { color: #64748b; font-size: 0.88rem; margin-bottom: 1.5rem; line-height: 1.5; max-width: 80ch; }
   .legend { display: flex; gap: 20px; margin-bottom: 1rem; font-size: 12px; }
   .dot { width: 12px; height: 12px; border-radius: 50%; display: inline-block; margin-right: 5px; vertical-align: middle; }
-  .nav { margin-top: 1.5rem; font-size: 0.8rem; color: #445566; }
-  .nav a { color: #57c4ad; text-decoration: none; margin: 0 0.5rem; }
+  .nav { margin-top: 1.5rem; font-size: 0.8rem; color: #94a3b8; }
+  .nav a { color: #2a9d8f; text-decoration: none; margin: 0 0.5rem; }
 </style>
 </head>
 <body>
@@ -46,8 +46,8 @@
 </div>
 
 <script>
-Chart.defaults.color = '#7a99b0';
-Chart.defaults.borderColor = '#1e3448';
+Chart.defaults.color = '#64748b';
+Chart.defaults.borderColor = '#e2e8f0';
 
 const DATES = ['Feb 26', 'Feb 27', 'Mar 9', 'Mar 10', 'Mar 20', 'Apr 9', 'Apr 13'];
 const SPECS = [
@@ -96,7 +96,7 @@ new Chart(document.getElementById('chart'), {
       label: 'Lines changed',
       data: absChange,
       backgroundColor: COLORS,
-      borderColor: '#0f1923',
+      borderColor: '#ffffff',
       borderWidth: 1,
       borderRadius: 5,
     }]
@@ -113,10 +113,10 @@ new Chart(document.getElementById('chart'), {
       }
     },
     scales: {
-      x: { ticks: { color: '#ccd6e0', font: { size: 12 } }, grid: { display: false } },
+      x: { ticks: { color: '#1a202c', font: { size: 12 } }, grid: { display: false } },
       y: {
-        ticks: { color: '#ccd6e0' }, grid: { color: '#1e3448' },
-        title: { display: true, text: 'Absolute lines changed', color: '#7a99b0', font: { size: 12 } }
+        ticks: { color: '#1a202c' }, grid: { color: '#e2e8f0' },
+        title: { display: true, text: 'Absolute lines changed', color: '#64748b', font: { size: 12 } }
       }
     }
   },
@@ -129,7 +129,7 @@ new Chart(document.getElementById('chart'), {
         const lines = NOTES[i].split('\n');
         ctx.save();
         ctx.font = '11px Segoe UI';
-        ctx.fillStyle = '#7a99b0';
+        ctx.fillStyle = '#64748b';
         ctx.textAlign = 'center';
         lines.forEach((line, li) => {
           ctx.fillText(line, bar.x, bar.y - 10 - (lines.length - 1 - li) * 14);

--- a/lotz-ivd/viz4_snapshot.html
+++ b/lotz-ivd/viz4_snapshot.html
@@ -5,19 +5,19 @@
 <title>Viz 4 · Final Snapshot</title>
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
 <style>
-  body { background: #0f1923; color: #ccd6e0; font-family: 'Segoe UI', system-ui, sans-serif;
+  body { background: #f5f7fa; color: #1a202c; font-family: 'Segoe UI', system-ui, sans-serif;
          display: flex; flex-direction: column; align-items: center; justify-content: center;
          min-height: 100vh; margin: 0; padding: 2rem; }
-  .card { background: #162433; border-radius: 14px; padding: 2rem 2.5rem;
-          border: 1px solid #1e3448; width: 100%; max-width: 960px; }
-  h2 { color: white; font-size: 1.4rem; margin-bottom: 0.3rem; }
-  .desc { color: #7a99b0; font-size: 0.88rem; margin-bottom: 1.5rem; line-height: 1.5; max-width: 80ch; }
+  .card { background: #ffffff; border-radius: 14px; padding: 2rem 2.5rem;
+          border: 1px solid #e2e8f0; width: 100%; max-width: 960px; }
+  h2 { color: #1a202c; font-size: 1.4rem; margin-bottom: 0.3rem; }
+  .desc { color: #64748b; font-size: 0.88rem; margin-bottom: 1.5rem; line-height: 1.5; max-width: 80ch; }
   .stats { display: flex; gap: 1.2rem; margin-bottom: 1.8rem; flex-wrap: wrap; }
-  .stat { background: #1a2e40; border-radius: 10px; padding: 0.9rem 1.3rem; flex: 1; min-width: 120px; text-align: center; border: 1px solid #1e3448; }
+  .stat { background: #f0f4f8; border-radius: 10px; padding: 0.9rem 1.3rem; flex: 1; min-width: 120px; text-align: center; border: 1px solid #e2e8f0; }
   .stat .num { font-size: 1.9rem; font-weight: 700; line-height: 1; }
-  .stat .lbl { font-size: 0.72rem; color: #7a99b0; margin-top: 0.35rem; line-height: 1.35; }
-  .nav { margin-top: 1.5rem; font-size: 0.8rem; color: #445566; }
-  .nav a { color: #57c4ad; text-decoration: none; margin: 0 0.5rem; }
+  .stat .lbl { font-size: 0.72rem; color: #64748b; margin-top: 0.35rem; line-height: 1.35; }
+  .nav { margin-top: 1.5rem; font-size: 0.8rem; color: #94a3b8; }
+  .nav a { color: #2a9d8f; text-decoration: none; margin: 0 0.5rem; }
 </style>
 </head>
 <body>
@@ -33,7 +33,7 @@
     <div class="stat"><div class="num" style="color:#e9c46a">2,155</div><div class="lbl">lines of spec<br>today</div></div>
     <div class="stat"><div class="num" style="color:#57c4ad">17,078</div><div class="lbl">words of human<br>instruction</div></div>
     <div class="stat"><div class="num" style="color:#e76f51">+778</div><div class="lbl">net lines added<br>since day 1</div></div>
-    <div class="stat"><div class="num" style="color:#a8dadc">7</div><div class="lbl">rounds of<br>human revision</div></div>
+    <div class="stat"><div class="num" style="color:#2a9d8f">7</div><div class="lbl">rounds of<br>human revision</div></div>
     <div class="stat"><div class="num" style="color:#f4a261">13</div><div class="lbl">spec modules<br>(was 11)</div></div>
   </div>
 
@@ -48,8 +48,8 @@
 </div>
 
 <script>
-Chart.defaults.color = '#7a99b0';
-Chart.defaults.borderColor = '#1e3448';
+Chart.defaults.color = '#64748b';
+Chart.defaults.borderColor = '#e2e8f0';
 
 const SPECS = [
   '00 Project','01 Discovery','02 Metadata','03 Preprocessing','04 Annotation',
@@ -93,11 +93,11 @@ new Chart(document.getElementById('chart'), {
     },
     scales: {
       x: {
-        ticks: { color: '#ccd6e0' }, grid: { color: '#1e3448' },
-        title: { display: true, text: 'Lines of spec', color: '#7a99b0', font: { size: 12 } }
+        ticks: { color: '#1a202c' }, grid: { color: '#e2e8f0' },
+        title: { display: true, text: 'Lines of spec', color: '#64748b', font: { size: 12 } }
       },
       y: {
-        ticks: { color: '#ccd6e0', font: { size: 12 } },
+        ticks: { color: '#1a202c', font: { size: 12 } },
         grid: { display: false }
       }
     }
@@ -111,7 +111,7 @@ new Chart(document.getElementById('chart'), {
         const val = sorted[i].v;
         const pct = (val / total * 100).toFixed(0);
         ctx.save();
-        ctx.fillStyle = '#ccd6e0';
+        ctx.fillStyle = '#1a202c';
         ctx.font = '11px Segoe UI';
         ctx.textAlign = 'left';
         ctx.fillText(`${val}  (${pct}%)`, bar.x + 6, bar.y + 4);

--- a/lotz-ivd/viz5_integration.html
+++ b/lotz-ivd/viz5_integration.html
@@ -5,25 +5,25 @@
 <title>Viz 5 · Integration Spec Deep Dive</title>
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
 <style>
-  body { background: #0f1923; color: #ccd6e0; font-family: 'Segoe UI', system-ui, sans-serif;
+  body { background: #f5f7fa; color: #1a202c; font-family: 'Segoe UI', system-ui, sans-serif;
          display: flex; flex-direction: column; align-items: center; justify-content: center;
          min-height: 100vh; margin: 0; padding: 2rem; }
-  .card { background: #162433; border-radius: 14px; padding: 2rem 2.5rem;
-          border: 1px solid #1e3448; width: 100%; max-width: 960px; }
-  h2 { color: white; font-size: 1.4rem; margin-bottom: 0.3rem; }
-  .desc { color: #7a99b0; font-size: 0.88rem; margin-bottom: 1.5rem; line-height: 1.5; max-width: 80ch; }
+  .card { background: #ffffff; border-radius: 14px; padding: 2rem 2.5rem;
+          border: 1px solid #e2e8f0; width: 100%; max-width: 960px; }
+  h2 { color: #1a202c; font-size: 1.4rem; margin-bottom: 0.3rem; }
+  .desc { color: #64748b; font-size: 0.88rem; margin-bottom: 1.5rem; line-height: 1.5; max-width: 80ch; }
   .annotation-list { display: grid; grid-template-columns: repeat(auto-fill, minmax(220px,1fr));
                      gap: 0.8rem; margin-top: 1.5rem; }
-  .ann { background: #1a2e40; border-radius: 8px; padding: 0.8rem 1rem;
+  .ann { background: #f0f4f8; border-radius: 8px; padding: 0.8rem 1rem;
          border-left: 3px solid #e76f51; font-size: 0.8rem; line-height: 1.4; }
   .ann .date { color: #e76f51; font-weight: 600; font-size: 0.75rem; margin-bottom: 0.2rem; }
-  .ann .msg  { color: #ccd6e0; }
-  .ann.teal  { border-left-color: #57c4ad; }
-  .ann.teal .date { color: #57c4ad; }
-  .ann.gold  { border-left-color: #e9c46a; }
-  .ann.gold .date { color: #e9c46a; }
-  .nav { margin-top: 1.5rem; font-size: 0.8rem; color: #445566; }
-  .nav a { color: #57c4ad; text-decoration: none; margin: 0 0.5rem; }
+  .ann .msg  { color: #1a202c; }
+  .ann.teal  { border-left-color: #2a9d8f; }
+  .ann.teal .date { color: #2a9d8f; }
+  .ann.gold  { border-left-color: #c47c00; }
+  .ann.gold .date { color: #c47c00; }
+  .nav { margin-top: 1.5rem; font-size: 0.8rem; color: #94a3b8; }
+  .nav a { color: #2a9d8f; text-decoration: none; margin: 0 0.5rem; }
 </style>
 </head>
 <body>
@@ -75,8 +75,8 @@
 </div>
 
 <script>
-Chart.defaults.color = '#7a99b0';
-Chart.defaults.borderColor = '#1e3448';
+Chart.defaults.color = '#64748b';
+Chart.defaults.borderColor = '#e2e8f0';
 
 const DATES = ['Feb 26', 'Feb 27', 'Mar 9', 'Mar 10', 'Mar 20', 'Apr 9', 'Apr 13'];
 const INTEGRATION = [158, 170, 355, 228, 228, 425, 488];
@@ -141,7 +141,7 @@ new Chart(document.getElementById('chart'), {
     responsive: true,
     plugins: {
       legend: {
-        labels: { color: '#ccd6e0', boxWidth: 16, font: { size: 12 } }
+        labels: { color: '#1a202c', boxWidth: 16, font: { size: 12 } }
       },
       tooltip: {
         callbacks: {
@@ -153,11 +153,11 @@ new Chart(document.getElementById('chart'), {
       }
     },
     scales: {
-      x: { ticks: { color: '#ccd6e0', font: { size: 12 } }, grid: { color: '#1e3448' } },
+      x: { ticks: { color: '#1a202c', font: { size: 12 } }, grid: { color: '#e2e8f0' } },
       y: {
-        ticks: { color: '#ccd6e0', callback: v => v + '%' },
-        grid: { color: '#1e3448' },
-        title: { display: true, text: 'Growth index (Feb 26 = 100)', color: '#7a99b0', font: { size: 12 } }
+        ticks: { color: '#1a202c', callback: v => v + '%' },
+        grid: { color: '#e2e8f0' },
+        title: { display: true, text: 'Growth index (Feb 26 = 100)', color: '#64748b', font: { size: 12 } }
       }
     }
   },

--- a/lotz-ivd/viz6_contributors.html
+++ b/lotz-ivd/viz6_contributors.html
@@ -6,64 +6,65 @@
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
 <style>
   :root {
-    --bg: #0f1923; --surface: #162433; --border: #1e3448;
+    --bg: #f5f7fa; --surface: #ffffff; --border: #e2e8f0;
     --info: #2a9d8f; --domain: #e76f51;
-    --andrew: #57c4ad; --goodb: #1a6b96;
-    --lisa: #e76f51; --hannah: #f4a261;
-    --claude: rgba(233,196,106,0.18);
+    --andrew: #2a9d8f; --goodb: #1a6b96;
+    --lisa: #e76f51; --hannah: #e06020;
+    --claude: rgba(196,124,0,0.12);
   }
   * { box-sizing: border-box; margin: 0; padding: 0; }
-  body { background: var(--bg); color: #ccd6e0;
+  body { background: var(--bg); color: #1a202c;
          font-family: 'Segoe UI', system-ui, sans-serif;
          display: flex; flex-direction: column; align-items: center;
          min-height: 100vh; padding: 2rem; }
   .card { background: var(--surface); border-radius: 14px; padding: 2rem 2.5rem;
           border: 1px solid var(--border); width: 100%; max-width: 1040px; margin-bottom: 1.5rem; }
-  h1 { color: white; font-size: 1.5rem; margin-bottom: 0.25rem; }
-  .sub { color: #7a99b0; font-size: 0.88rem; margin-bottom: 0; }
-  h2 { color: white; font-size: 1.1rem; margin-bottom: 0.3rem; }
-  .desc { color: #7a99b0; font-size: 0.83rem; margin-bottom: 1.2rem; line-height: 1.5; max-width: 90ch; }
+  h1 { color: #1a202c; font-size: 1.5rem; margin-bottom: 0.25rem; }
+  .sub { color: #64748b; font-size: 0.88rem; margin-bottom: 0; }
+  h2 { color: #1a202c; font-size: 1.1rem; margin-bottom: 0.3rem; }
+  .desc { color: #64748b; font-size: 0.83rem; margin-bottom: 1.2rem; line-height: 1.5; max-width: 90ch; }
 
   /* ── Swimlane ── */
   .swimlane { position: relative; width: 100%; margin-bottom: 0.5rem; }
   .lane { display: flex; align-items: center; margin-bottom: 6px; }
-  .lane-label { width: 110px; font-size: 11px; color: #7a99b0; flex-shrink: 0; text-align: right; padding-right: 10px; }
-  .lane-track { flex: 1; position: relative; height: 52px; background: #111e2a; border-radius: 6px; }
+  .lane-label { width: 110px; font-size: 11px; color: #64748b; flex-shrink: 0; text-align: right; padding-right: 10px; }
+  .lane-track { flex: 1; position: relative; height: 52px; background: #f0f4f8; border-radius: 6px; }
   .commit-bubble {
     position: absolute; top: 50%; transform: translate(-50%, -50%);
     border-radius: 50%; cursor: pointer; transition: opacity 0.15s;
     display: flex; align-items: center; justify-content: center;
     font-size: 9px; color: white; font-weight: 700;
-    border: 2px solid rgba(255,255,255,0.15);
+    border: 2px solid rgba(255,255,255,0.6);
   }
   .commit-bubble:hover { opacity: 0.8; }
-  .commit-bubble.claude-ring { box-shadow: 0 0 0 3px rgba(233,196,106,0.5); }
-  .timeline-axis { display: flex; margin-left: 110px; font-size: 10px; color: #445566; margin-top: 4px; position: relative; }
+  .commit-bubble.claude-ring { box-shadow: 0 0 0 3px rgba(196,124,0,0.45); }
+  .timeline-axis { display: flex; margin-left: 110px; font-size: 10px; color: #94a3b8; margin-top: 4px; position: relative; }
   .axis-tick { position: absolute; transform: translateX(-50%); }
 
   /* ── Role totals ── */
   .role-row { display: flex; gap: 1rem; margin-bottom: 1.5rem; flex-wrap: wrap; }
-  .role-card { background: #1a2e40; border-radius: 10px; padding: 1rem 1.4rem; flex: 1; min-width: 160px;
+  .role-card { background: #f0f4f8; border-radius: 10px; padding: 1rem 1.4rem; flex: 1; min-width: 160px;
                border-left: 4px solid; }
   .role-card .num  { font-size: 1.8rem; font-weight: 700; line-height: 1; }
-  .role-card .name { font-size: 0.78rem; color: #7a99b0; margin-top: 0.2rem; }
-  .role-card .sub2 { font-size: 0.72rem; color: #445566; margin-top: 0.15rem; }
+  .role-card .name { font-size: 0.78rem; color: #64748b; margin-top: 0.2rem; }
+  .role-card .sub2 { font-size: 0.72rem; color: #94a3b8; margin-top: 0.15rem; }
 
   /* ── Tooltip ── */
   #tooltip {
-    position: fixed; background: #1a2e40; border: 1px solid #334455;
+    position: fixed; background: #ffffff; border: 1px solid #e2e8f0;
     border-radius: 8px; padding: 0.6rem 0.9rem; font-size: 12px;
     pointer-events: none; display: none; z-index: 100; max-width: 260px; line-height: 1.5;
+    box-shadow: 0 4px 12px rgba(0,0,0,0.1);
   }
-  #tooltip strong { color: white; }
+  #tooltip strong { color: #1a202c; }
   #tooltip .tt-role { font-size: 10px; border-radius: 3px; padding: 1px 5px; margin-left: 4px; }
 
-  .nav { margin-top: 1rem; font-size: 0.8rem; color: #445566; text-align: center; }
-  .nav a { color: #57c4ad; text-decoration: none; margin: 0 0.5rem; }
+  .nav { margin-top: 1rem; font-size: 0.8rem; color: #94a3b8; text-align: center; }
+  .nav a { color: #2a9d8f; text-decoration: none; margin: 0 0.5rem; }
   .legend-row { display: flex; gap: 1.2rem; flex-wrap: wrap; margin-bottom: 1.2rem; font-size: 12px; align-items: center; }
   .dot { width: 11px; height: 11px; border-radius: 50%; display: inline-block; margin-right: 4px; vertical-align: middle; }
   .claude-dot { width: 11px; height: 11px; border-radius: 50%; display: inline-block; margin-right: 4px; vertical-align: middle;
-                background: rgba(233,196,106,0.4); border: 2px solid #e9c46a; }
+                background: rgba(196,124,0,0.2); border: 2px solid #c47c00; }
 </style>
 </head>
 <body>
@@ -152,8 +153,8 @@
 </div>
 
 <script>
-Chart.defaults.color = '#7a99b0';
-Chart.defaults.borderColor = '#1e3448';
+Chart.defaults.color = '#64748b';
+Chart.defaults.borderColor = '#e2e8f0';
 
 // ── All 15 commits ──────────────────────────────────────────────────────────
 const COMMITS = [
@@ -242,8 +243,8 @@ AUTHORS.forEach(author => {
       tooltip.innerHTML = `
         <strong>${c.author}</strong>${roleLabel}<br>
         ${c.date} · <span style="color:${c.delta>=0?'#57c4ad':'#e76f51'}">${c.delta>=0?'+':''}${c.delta} lines</span><br>
-        ${c.claude ? '<span style="color:#e9c46a;font-size:10px">✦ Claude co-authored</span><br>' : ''}
-        <span style="color:#7a99b0;font-size:11px">${c.msg}</span>
+        ${c.claude ? '<span style="color:#c47c00;font-size:10px">✦ Claude co-authored</span><br>' : ''}
+        <span style="color:#64748b;font-size:11px">${c.msg}</span>
       `;
       tooltip.style.display = 'block';
     });
@@ -312,7 +313,7 @@ new Chart(document.getElementById('chart'), {
       {
         label: 'Total spec lines',
         data: totalLine,
-        borderColor: '#ccd6e0',
+        borderColor: '#334155',
         backgroundColor: 'transparent',
         pointBackgroundColor: COMMITS.map(c => c.color),
         pointRadius: 7,
@@ -338,7 +339,7 @@ new Chart(document.getElementById('chart'), {
   options: {
     responsive: true,
     plugins: {
-      legend: { labels: { color: '#ccd6e0', boxWidth: 14 } },
+      legend: { labels: { color: '#1a202c', boxWidth: 14 } },
       tooltip: {
         callbacks: {
           label: (ctx) => {
@@ -355,9 +356,9 @@ new Chart(document.getElementById('chart'), {
       }
     },
     scales: {
-      x: { ticks: { color: '#ccd6e0', font: { size: 10 }, maxRotation: 40 }, grid: { color: '#1e3448' } },
-      y: { ticks: { color: '#ccd6e0' }, grid: { color: '#1e3448' },
-           title: { display: true, text: 'Total lines', color: '#7a99b0' } }
+      x: { ticks: { color: '#1a202c', font: { size: 10 }, maxRotation: 40 }, grid: { color: '#e2e8f0' } },
+      y: { ticks: { color: '#1a202c' }, grid: { color: '#e2e8f0' },
+           title: { display: true, text: 'Total lines', color: '#64748b' } }
     }
   },
   plugins: [phasePlugin]
@@ -394,9 +395,9 @@ new Chart(document.getElementById('chart2'), {
       }
     },
     scales: {
-      x: { ticks: { color: '#ccd6e0', font: { size: 10 }, maxRotation: 40 }, grid: { display: false } },
-      y: { ticks: { color: '#ccd6e0' }, grid: { color: '#1e3448' },
-           title: { display: true, text: '|Lines changed|', color: '#7a99b0' } }
+      x: { ticks: { color: '#1a202c', font: { size: 10 }, maxRotation: 40 }, grid: { display: false } },
+      y: { ticks: { color: '#1a202c' }, grid: { color: '#e2e8f0' },
+           title: { display: true, text: '|Lines changed|', color: '#64748b' } }
     }
   },
   plugins: [phasePlugin]


### PR DESCRIPTION
Replace dark navy background with light (#f5f7fa / #ffffff cards), update all text, border, grid, and accent colors for readability on light bg.

